### PR TITLE
Add a proper uppercase function and fix a bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# vscode settings
 /.vscode
+
+# error logs
+*.log

--- a/test/errorlog.log
+++ b/test/errorlog.log
@@ -1,1 +1,0 @@
-1c1 < Connect server [127.0.0.1:48763] success Please input your message: get receive message from [127.0.0.1:48763]: OUO Please input your message: get receive message from [127.0.0.1:48763]: ZOOZ Please input your message: --- > Connect server [127.0.0.1:48763] success Please input your message: get receive message from [127.0.0.1:48763]: OUO Please input your message:


### PR DESCRIPTION
```c
 if (send(info->sockfd, conv, sizeof(conv), 0) < 0) {
      printf("send data to %s:%d, failed!\n", 
              inet_ntoa(info->clientAddr.sin_addr), ntohs(info->clientAddr.sin_port));
      memset(buf, 0, sizeof(buf));
      free(conv);
      break;
  }
```
因為  `char *conv = convert(buf);`  的大小 != buf 的size 導致server會傳送的訊息比實際要傳送的短
所以把`conv` 的 `size` 跟 `buf` 的 `size` 用 `malloc` 同步，但如果在其他地方有bof的話就可以輕易地使用 double free 去達成write everywhere 所以可能不是一個好的更改方式。
```c
// 將收到的英文字母換成大寫
char *conv = malloc(sizeof(buf));
memcpy(conv, convert(buf), sizeof(buf));
```
P.S. 順手把`convert`裡面的東西改成合理一點的`function` [See reference](https://man7.org/linux/man-pages/man3/tolower.3.html)